### PR TITLE
Now made players have the same in game size

### DIFF
--- a/Assets/Scenes/Test room.unity
+++ b/Assets/Scenes/Test room.unity
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:e79369b06b18e5dbe90450eee066de49a932c869ab4c2a3a4be34f91e08c6a85
-size 151990
+oid sha256:f4afc79284fc80ba17f199f51965d8e47376b37607ba2fa5464f3aa47d923ab0
+size 151995

--- a/Assets/XR Custom/XR Origin custom.prefab
+++ b/Assets/XR Custom/XR Origin custom.prefab
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:5f59442306f271b2924c335de8a29dd1525ae3c6faae7ebea61fd09ea4c6c267
-size 97467
+oid sha256:188ec1f10ef8191d887bf67b401fb648b862fd6526e10e37abdcc53d875189f0
+size 98677


### PR DESCRIPTION
**Taille des joueurs normalizée**
* Simple tweak des fields du prefab suffisent donc aucun changement en scripts
* Trigger box de la plateforme plus haute, j'abandonne l'idée de comprendre pourquoi elle doit être si haute pour collide correctement avec le joueur (j'exagère c'est pas si haut que ça mais quand même)
* **Playtest**: J'ai la même taille (après calibration du casque) debout qu'à genoux dans le jeu, ça fonctionne bien.

Note : Il est peut - être nécessaire de repositionner ce prefab dans vos scène car il est plus haut maintenant, pas que le joueur spawn dans le sol.